### PR TITLE
feat: add interpolating data to template helpers

### DIFF
--- a/app/lib/config.js
+++ b/app/lib/config.js
@@ -18,6 +18,12 @@ environments.staging = {
     authToken: process.env.TWILIO_AUTH_TOKEN,
     fromPhone: process.env.TWILIO_FROM_PHONE,
   },
+  templateGlobals: {
+    appName: 'UptimeChecker',
+    companyName: 'FakeComp. Pty Ltd',
+    yearCreated: '2018',
+    baseURL: 'http://localhost:3000/'
+  }
 }
 
 // Production environment
@@ -32,6 +38,12 @@ environments.production = {
     authToken: process.env.TWILIO_AUTH_TOKEN,
     fromPhone: process.env.TWILIO_FROM_PHONE,
   },
+  templateGlobals: {
+    appName: 'UptimeChecker',
+    companyName: 'FakeComp. Pty Ltd',
+    yearCreated: '2018',
+    baseURL: 'http://localhost:3000/'
+  }
 }
 
 // Get environment from command line argument

--- a/app/lib/handlers/html/root.js
+++ b/app/lib/handlers/html/root.js
@@ -4,7 +4,8 @@ const helpers = require('../../helpers')
  * @name RootHandler
  * @desc The index handler for the web application
  * @param data {any}
- * @param callback {(statusCode?: number, payload?: any, contentType?: 'json' | 'html') => void}
+ * @param callback {(statusCode?: number, payload?: any, contentType?: 'json' |
+ *   'html') => void}
  * @return {void}
  */
 function rootHandler(data, callback) {
@@ -13,13 +14,27 @@ function rootHandler(data, callback) {
     return callback(405, undefined, 'html')
   }
 
+  // Prepare data for interpolation
+  const templateData = {
+    'head.title': 'This is the title',
+    'head.description': 'This is the meta description',
+    'body.title': 'Hello templated world!',
+    'body.class': 'index',
+  }
+
   // Read in a template as a string
-  helpers.getTemplate('index', (err, string) => {
-    if (err || !string) {
-      return callback(500, undefined, 'html');
+  helpers.getTemplate('index', templateData, (err, rawTemplate) => {
+    if (err || !rawTemplate) {
+      return callback(500, undefined, 'html')
     }
 
-    return callback(200, string, 'html')
+    helpers.addUniversalTemplates(rawTemplate, templateData, (err, template) => {
+      if (err || !template) {
+        return callback(500, undefined, 'html')
+      }
+
+      return callback(200, template, 'html')
+    })
   })
 }
 

--- a/app/lib/helpers.js
+++ b/app/lib/helpers.js
@@ -129,23 +129,108 @@ const sendTwilioSms = function(phone, message, callback) {
  * @name GetTemplate
  * @desc Gets the string content of a template
  * @param name {string} Name of the template
+ * @param data {object}
  * @param callback {(error: string | false, template?: string) => void}
  * @return {void}
  */
-function getTemplate(name, callback) {
+function getTemplate(name, data, callback) {
   if (typeof name !== 'string' || !name.length) {
     return callback('A valid template name was not specified.')
   }
 
   const templatesDir = path.join(__dirname, '/../templates/')
 
-  fs.readFile(templatesDir + name + '.html', 'utf-8', (err, template) => {
-    if (err || !template || !template.length) {
+  fs.readFile(templatesDir + name + '.html', 'utf-8', (err, rawTemplate) => {
+    if (err || !rawTemplate || !rawTemplate.length) {
       return callback('No template was found')
     }
 
+    // Interpolate the input
+    const template = interpolateTemplate(rawTemplate, data)
+
     return callback(false, template)
   })
+}
+
+/**
+ * @name AddUniversalTemplates
+ * @desc Add the universal header and footer to a string, and pass the data
+ *   object to the header and footer for interpolation
+ * @param input {string} templateInput
+ * @param data {object} Data to fill into the template
+ * @param callback {(error?: string | false, template?: string) => void}
+ */
+function addUniversalTemplates(input, data, callback) {
+  input = typeof (input) === 'string' && !!input.length ? input : ''
+  data = typeof (data) === 'object' && !!data ? data : {}
+
+  // Get meta, header and footer templates
+  getTemplate('_meta', data, (err, metaTemplate) => {
+    if (err || !metaTemplate) {
+      return callback('Could not find the meta template')
+    }
+
+    getTemplate('_header', data, (err, headerTemplate) => {
+      if (err || !headerTemplate) {
+        return callback('Could not find the header template')
+      }
+
+      getTemplate('_footer', data, (err, footerTemplate) => {
+        if (err || !footerTemplate) {
+          return callback('Could not find the footer template')
+        }
+
+        const combinedTemplate = [
+          '<html lang="en">\n',
+          metaTemplate,
+          '<body class="{body.class}">\n' +
+          '<!-- Page Wrapper -->\n' +
+          '<div class="wrapper">\n',
+          headerTemplate,
+          '<div class="content">\n',
+          input,
+          '\n</div>\n',
+          footerTemplate,
+          '</body>\n' +
+          '</html>',
+        ].join('')
+
+        return callback(false, combinedTemplate)
+      })
+    })
+  })
+}
+
+
+/**
+ * @name InterpolateTemplate
+ * @desc Take a string and data object and find/replace all the keys within it
+ * @param input {string}
+ * @param data {object}
+ */
+function interpolateTemplate(input, data) {
+  input = typeof (input) === 'string' && !!input.length ? input : ''
+  data = typeof (data) === 'object' && !!data ? data : {}
+
+  // Add the templateGlobals to the data object
+  // Prepend their key name "global"
+  for (let keyName in config.templateGlobals) {
+    if (Object.hasOwn(config.templateGlobals, keyName)) {
+      data['global.' + keyName] = config.templateGlobals[keyName]
+    }
+  }
+
+  // Insert each value into the input at the corresponding placeholder
+  for (let key in data) {
+    if (Object.hasOwn(data, key) && typeof data[key] === 'string') {
+      const replace = data[key]
+      const find = `{${key}}`
+
+      input = input.replace(find, replace)
+    }
+  }
+
+  return input
 }
 
 module.exports = {
@@ -153,5 +238,7 @@ module.exports = {
   parseJsonToObject,
   createRandomString,
   sendTwilioSms,
-  getTemplate
+  getTemplate,
+  addUniversalTemplates,
+  interpolateTemplate,
 }

--- a/app/templates/_footer.html
+++ b/app/templates/_footer.html
@@ -1,0 +1,5 @@
+
+<!-- Footer -->
+<div class="footer">
+  <div class="copyright">Copyright {global.yearCreated} {global.companyName} | All Rights Reserved</div>
+</div>

--- a/app/templates/_header.html
+++ b/app/templates/_header.html
@@ -1,0 +1,29 @@
+
+<!-- Header -->
+<div class='header'>
+  <!-- Logo -->
+  <a class='logo' href='/'></a>
+  <!-- Navigation -->
+  <ul class='menu'>
+    <li>
+      <a href='/'>Home</a>
+    </li>
+    <li class='loggedOut'>
+      <a href='/'>Signup</a>
+    </li>
+    <li class='loggedOut'>
+      <a href='/'>Login</a>
+    </li>
+    <li class='loggedIn'>
+      <a href='/'>Dashboard</a>
+    </li>
+    <li class='loggedIn'>
+      <a href='/'>Account Settings</a>
+    </li>
+    <li class='loggedIn'>
+      <a href='/'>Logout</a>
+    </li>
+  </ul>
+</div>
+
+<!-- Page-Specific Content -->

--- a/app/templates/_meta.html
+++ b/app/templates/_meta.html
@@ -1,0 +1,15 @@
+<head>
+  <!-- General Settings -->
+  <meta charset="utf-8">
+  <meta http-equiv="content-language" content="en-us">
+  <base href="{global.baseUrl}" />
+
+  <!-- Meta Tags -->
+  <title>{head.title} | {global.appName}</title>
+  <meta name="description" content="{head.description}">
+
+  <!-- Static Assets -->
+  <link type="image/x-icon" rel="icon" href="favicon.ico">
+  <script type="text/javascript" charset="utf-8" src="public/app.js"></script>
+  <link rel="stylesheet" type="text/css" href="public/app.css" />
+</head>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,9 +1,1 @@
-<html lang='en'>
-  <head>
-    <title>Hello World</title>
-  </head>
-
-  <body>
-    <h1>Hello world!</h1>
-  </body>
-</html>
+<h1>{body.title}</h1>


### PR DESCRIPTION
This lesson introduces creating interpolating templates. It covers combining multiple templates into one while providing a custom template for the content. I broke down the templates more by creaating a **_meta.html** and moving unclosed tags to be handled in the `addUniversalTemplates()` function.

**Changes**
- [feat: add interpolating data to template helpers](https://github.com/ryancrumble/node-master-class/commit/6785d9edd7b4a471ae0a1fff18c2eb23cb26486f)